### PR TITLE
Add object notation for variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ You'll define your presentational components:
 import { Box, Comp } from 'classier-react'
 
 const Card = props => (
-  <Box rounded shadow="lg" maxW="sm" overflow="hidden" {...props} />
+  <Box
+    rounded
+    shadow={['md', { hover: 'lg' }]}
+    maxW="sm"
+    overflow="hidden"
+    {...props}
+  />
 )
 
 const CardHeroImage = ({ src, ...rest }) => (
@@ -62,8 +68,8 @@ And then consume them as usual:
 ```jsx
 <Card maxW="md">
   <CardHeroImage src={image} border={false} />
-  <CardTitle>So Classy</CardTitle>
-  <CardBody>Lorem ipsum...</CardBody>
+  <CardTitle size={4}>So Classy</CardTitle>
+  <CardBody font="semibold">Lorem ipsum...</CardBody>
 </Card>
 ```
 
@@ -76,6 +82,8 @@ Under the hood, `classier-react` assumes any unknown props are declared as modif
 - prop values are appended to their names
 
   - each value of an array will generate its own prop class
+
+  - each key of an object will generate a variant prop class
 
 - camelCase words become kebab-cased
 
@@ -165,4 +173,6 @@ Lets you change the global behavior of `cx`
 
 - **join.words** - the string to insert between the words in a camelCase identifier (_default: '-'_)
 
-- **join.value** - the string to insert to separate a value (_default: '-'_)
+- **join.value** - the string used to separate a value (_default: '-'_)
+
+- **join.variant** - the string used to separate a variant from its modifier(_default: ':'_)

--- a/src/transform.js
+++ b/src/transform.js
@@ -33,6 +33,12 @@ function toClassNames(name, value) {
     return value.map(inner => toClassNames(name, inner))
   }
 
+  if (typeof value === 'object') {
+    return Object.keys(value).map(variant =>
+      toClassNames(`${variant}${config.join.variant}${name}`, value[variant])
+    )
+  }
+
   return toStyleName(name, value)
 }
 

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -27,6 +27,14 @@ describe('cx:', () => {
     expect(res).toEqual('chicken-tasty chicken-dinner')
   })
 
+  test('should transform propClasses with variants', () => {
+    const res = cx({
+      chicken: ['dinner', { morning: 'breakfast' }]
+    })
+
+    expect(res).toEqual('chicken-dinner morning:chicken-breakfast')
+  })
+
   test('should transform propClasses with CamelCase names', () => {
     const res = cx({
       CamelHumps: 'LovelyCamelHumps'


### PR DESCRIPTION
This PR adds support for tailwind variants by allowing objects in `cx` prop values. 

```js
<Box w={[ 'full', { md: '4/5', lg: '3/5' } ]} />
```

The key names of any object are prefixed to the prop name and the object values are appended following the same rules as every other normal value. 

```
w-full md:w-4/5 lg:w-3/5
```

Things to consider:
- Is this useful for any other frameworks?
  - bootstrap mixes variants as an extension block to the modifier: `col-md-6`
- What else could objects do?
  - blocks? `Card={ header: 'bold', border: 'md' } => Card__header-bold Card__border-md`